### PR TITLE
fix(pixiv): use /artworks/{id} instead of /i/{id}

### DIFF
--- a/src/command/pixiv.rs
+++ b/src/command/pixiv.rs
@@ -48,13 +48,13 @@ impl Context {
                         .collect::<Vec<String>>()
                         .join(" ");
                     let this_line = format!(
-                        "\n#{idx}: {title} https://pixiv.net/artworks/{illust_id} | {tag_str}",
+                        "\n#{idx}: {title} https://www.pixiv.net/artworks/{illust_id} | {tag_str}",
                         idx = idx,
                         title = illust.title,
                         illust_id = illust.illust_id
                     );
                     let this_line_html = format!(
-                        "<br/>#{idx}: <a href='https://pixiv.net/artworks/{illust_id}'>{title}</a> | {tag_html_str}",
+                        "<br/>#{idx}: <a href='https://www.pixiv.net/artworks/{illust_id}'>{title}</a> | {tag_html_str}",
                         idx = idx,
                         title = illust.title,
                         illust_id = illust.illust_id
@@ -99,13 +99,13 @@ impl Context {
                     .map(|s| format!("<br/><b><font color='#d72b6d'>#{s}诱捕器</font></b>"))
                     .unwrap_or_default();
                 let body = format!(
-                    "{title} https://pixiv.net/artworks/{id}\n{tag_str}\nAuthor: {author}{specials_str}",
+                    "{title} https://www.pixiv.net/artworks/{id}\n{tag_str}\nAuthor: {author}{specials_str}",
                     title = resp.title,
                     id = resp.id,
                     author = resp.user_name
                 );
                 let html_body = format!(
-                    "<a href='https://pixiv.net/artworks/{id}'>{title}</a><br/>{tag_html_str}<br/>Author: {author}{specials_str_html}",
+                    "<a href='https://www.pixiv.net/artworks/{id}'>{title}</a><br/>{tag_html_str}<br/>Author: {author}{specials_str_html}",
                     title = resp.title,
                     id = resp.id,
                     author = resp.user_name

--- a/src/command/pixiv.rs
+++ b/src/command/pixiv.rs
@@ -48,13 +48,13 @@ impl Context {
                         .collect::<Vec<String>>()
                         .join(" ");
                     let this_line = format!(
-                        "\n#{idx}: {title} https://pixiv.net/i/{illust_id} | {tag_str}",
+                        "\n#{idx}: {title} https://pixiv.net/artworks/{illust_id} | {tag_str}",
                         idx = idx,
                         title = illust.title,
                         illust_id = illust.illust_id
                     );
                     let this_line_html = format!(
-                        "<br/>#{idx}: <a href='https://pixiv.net/i/{illust_id}'>{title}</a> | {tag_html_str}",
+                        "<br/>#{idx}: <a href='https://pixiv.net/artworks/{illust_id}'>{title}</a> | {tag_html_str}",
                         idx = idx,
                         title = illust.title,
                         illust_id = illust.illust_id
@@ -99,13 +99,13 @@ impl Context {
                     .map(|s| format!("<br/><b><font color='#d72b6d'>#{s}诱捕器</font></b>"))
                     .unwrap_or_default();
                 let body = format!(
-                    "{title} https://pixiv.net/i/{id}\n{tag_str}\nAuthor: {author}{specials_str}",
+                    "{title} https://pixiv.net/artworks/{id}\n{tag_str}\nAuthor: {author}{specials_str}",
                     title = resp.title,
                     id = resp.id,
                     author = resp.user_name
                 );
                 let html_body = format!(
-                    "<a href='https://pixiv.net/i/{id}'>{title}</a><br/>{tag_html_str}<br/>Author: {author}{specials_str_html}",
+                    "<a href='https://pixiv.net/artworks/{id}'>{title}</a><br/>{tag_html_str}<br/>Author: {author}{specials_str_html}",
                     title = resp.title,
                     id = resp.id,
                     author = resp.user_name

--- a/src/message/nahida/extractors/pixiv.rs
+++ b/src/message/nahida/extractors/pixiv.rs
@@ -37,13 +37,13 @@ pub async fn pixiv_illust(
         .map(|s| format!("<p><b><font color='#d72b6d'>#{s}诱捕器</font></b></p>"))
         .unwrap_or_default();
     let body = format!(
-        "[Pixiv/Illust] {title} https://pixiv.net/i/{id}\n{tag_str}\nAuthor: {author}{specials_str}",
+        "[Pixiv/Illust] {title} https://pixiv.net/artworks/{id}\n{tag_str}\nAuthor: {author}{specials_str}",
         title = resp.title,
         id = resp.id,
         author = resp.user_name
     );
     let html_body = format!(
-        "<p><b>[Pixiv/Illust]</b> <a href='https://pixiv.net/i/{id}'>{title}</a></p><p>{tag_html_str}</p><p>Author: {author}</p>{specials_str_html}",
+        "<p><b>[Pixiv/Illust]</b> <a href='https://pixiv.net/artworks/{id}'>{title}</a></p><p>{tag_html_str}</p><p>Author: {author}</p>{specials_str_html}",
         title = resp.title,
         id = resp.id,
         author = resp.user_name

--- a/src/message/nahida/extractors/pixiv.rs
+++ b/src/message/nahida/extractors/pixiv.rs
@@ -37,13 +37,13 @@ pub async fn pixiv_illust(
         .map(|s| format!("<p><b><font color='#d72b6d'>#{s}诱捕器</font></b></p>"))
         .unwrap_or_default();
     let body = format!(
-        "[Pixiv/Illust] {title} https://pixiv.net/artworks/{id}\n{tag_str}\nAuthor: {author}{specials_str}",
+        "[Pixiv/Illust] {title} https://www.pixiv.net/artworks/{id}\n{tag_str}\nAuthor: {author}{specials_str}",
         title = resp.title,
         id = resp.id,
         author = resp.user_name
     );
     let html_body = format!(
-        "<p><b>[Pixiv/Illust]</b> <a href='https://pixiv.net/artworks/{id}'>{title}</a></p><p>{tag_html_str}</p><p>Author: {author}</p>{specials_str_html}",
+        "<p><b>[Pixiv/Illust]</b> <a href='https://www.pixiv.net/artworks/{id}'>{title}</a></p><p>{tag_html_str}</p><p>Author: {author}</p>{specials_str_html}",
         title = resp.title,
         id = resp.id,
         author = resp.user_name


### PR DESCRIPTION
Untested. :P

Currently links like `https://pixiv.net/i/100588400` does not work with LibRedirect and PixivFE, which throws me a `500`.

Also avoids `301` on pixiv.net.

![image](https://github.com/ShadowRZ/fuuka-bot/assets/68757440/d47a48bd-8d52-487b-9f64-333784f03050)